### PR TITLE
refactored hello to zoomstackSites

### DIFF
--- a/main.py
+++ b/main.py
@@ -62,10 +62,9 @@ def create_filter_hello (propertyName, literal):
     return filters
 
 class Query(graphene.ObjectType):
-    #Update hello field with valid typenames Zoomstack_Sites
-    hello = graphene.List(graphene.String,
+
+    zoomstackSites = graphene.List(graphene.String,
         count=graphene.Int(default_value=10),
-        typeNames=graphene.String(default_value="osfeatures:Zoomstack_Sites"),
         propertyName=graphene.String(default_value=""),
         literal=graphene.String(default_value="")
     )
@@ -76,17 +75,16 @@ class Query(graphene.ObjectType):
     )
 
     #   {
-    #      hello(
+    #      zoomstackSites(
     #         count: 5,
-    #         propertyName: "Ward",
-    #         literal: "Bottisham Ward",
-    #         typeNames: "osfeatures:BoundaryLine_PollingDistrict"
+    #         propertyName: "Education",
+    #         literal: "Type",
     #     )
     # }
-    def resolve_hello(self, info, count, typeNames, propertyName, literal):
+    def resolve_zoomstackSites(self, info, count, propertyName, literal):
         if (count >= 0 ):
             filters = create_filter_hello(propertyName, literal)
-            return fetchFeaturesFromWFS(count, typeNames, filters)
+            return fetchFeaturesFromWFS(count = count, typeNames = "Zoomstack_Sites", filters = filters)
 
         else:
             return ["Error: Count needs to be 0 or more"]

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -16,45 +16,44 @@ class HelloTestCase(unittest.TestCase):
             data = Data()
         return Request()
 
-    def test_no_errors(self):
+    def test_zoomstackSites_no_errors(self):
         schema = graphene.Schema(query=Query)
         client = Client(schema)
-        query = ' { hello(count: 5, propertyName: "Type", literal: "Education") } '
+        query = ' { zoomstackSites(count: 5, propertyName: "Type", literal: "Education") } '
         executed = client.execute(query)
 
-        self.assertNotEqual(executed['data']['hello'][0], 'Error: Check your logs')
+        self.assertNotEqual(executed['data']['zoomstackSites'][0], 'Error: Check your logs')
 
-    def test_count_1_feature(self):
-        query = ' { hello(count: 1, propertyName: "Type", literal: "Education") } '
+    def test_zoomstackSites_count_1_feature(self):
+        query = ' { zoomstackSites(count: 1, propertyName: "Type", literal: "Education") } '
         request = self.make_request(query)
         result = graphqlwfs(request)
         
-        self.assertEqual(len(result["hello"]), 1)
+        self.assertEqual(len(result["zoomstackSites"]), 1)
 
-    def test_count_2_features(self):
-        query = ' { hello(count: 2, propertyName: "Type", literal: "Education") } '
+    def test_zoomstackSites_count_2_features(self):
+        query = ' { zoomstackSites(count: 2, propertyName: "Type", literal: "Education") } '
         request = self.make_request(query)
         result = graphqlwfs(request)
 
-        self.assertEqual(len(result["hello"]), 2)
+        self.assertEqual(len(result["zoomstackSites"]), 2)
     
-    def test_negative_count(self):
+    def test_zoomstackSites_negative_count(self):
         schema = graphene.Schema(query=Query)
         client = Client(schema)
-        query = ' { hello(count: -1, propertyName: "Type", literal: "Education") } '
+        query = ' { zoomstackSites(count: -1, propertyName: "Type", literal: "Education") } '
         executed = client.execute(query)
 
-        self.assertEqual(executed['data']['hello'][0],'Error: Count needs to be 0 or more')
+        self.assertEqual(executed['data']['zoomstackSites'][0],'Error: Count needs to be 0 or more')
 
-    def test_empty_filter(self):
+    def test_zoomstackSites_empty_filter(self):
         schema = graphene.Schema(query=Query)
         client = Client(schema)
-        query = ' { hello(count: 2, propertyName: " " , literal: "    ") } '
+        query = ' { zoomstackSites(count: 2, propertyName: " " , literal: "    ") } '
         executed = client.execute(query)
 
-        self.assertNotEqual(executed['data']['hello'][0], 'Error: Check your logs')
+        self.assertNotEqual(executed['data']['zoomstackSites'][0], 'Error: Check your logs')
     
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,7 +16,7 @@ class HelloTestCase(unittest.TestCase):
     def make_mocked_response(self,data):
         class mockResponse:
             status_code = 200
-            def json(_): return data
+            def json(self): return data
         return mockResponse()
 
     def make_request(self, query):
@@ -29,23 +29,22 @@ class HelloTestCase(unittest.TestCase):
 
     # @patch('main.requests.get', new=make_mocked_request_get('my query here'))
     @patch('main.requests.get')
-    def test_single_feature(self, mocked_get):
+    def test_zoomstackSites_one_feature(self, mocked_get):
         response_data = {"features": ["I'm getting this"]}
-        query = ' { hello(count: 2, propertyName: "Type", literal: "Education") } '
-        expected_value = {'hello': response_data["features"]}
+        query = ' { zoomstackSites(count: 2, propertyName: "Type", literal: "Education") } '
+        expected_value = {'zoomstackSites': response_data["features"]}
         mocked_get.return_value = self.make_mocked_response(response_data)
         request = self.make_request(query)
         result = graphqlwfs(request)
 
         self.assertEqual(result, expected_value)
 
-
     @patch('main.requests.get')
-    def test_two_features(self, mocked_get):
+    def test_zoomstackSites_two_features(self, mocked_get):
         response_data = {"features": ["I'm getting this 1", "I'm getting this 2"]}
-        query = ' { hello(count: 2, propertyName: "Type", literal: "Education") } '
+        query = ' { zoomstackSites(count: 2, propertyName: "Type", literal: "Education") } '
 
-        expected_value = {'hello': response_data["features"]}
+        expected_value = {'zoomstackSites': response_data["features"]}
         mocked_get.return_value = self.make_mocked_response(response_data)
         request = self.make_request(query)
         result = graphqlwfs(request)
@@ -53,11 +52,11 @@ class HelloTestCase(unittest.TestCase):
         self.assertEqual(result, expected_value)
     
     @patch('main.requests.get')
-    def test_empty_filter_parameters(self, mocked_get):
+    def test_zoomstackSites_empty_filter_parameters(self, mocked_get):
         response_data = {"features": ["I'm getting this 1", "I'm getting this 2", "I'm getting this also"]}
-        query = ' { hello(count: 2, propertyName: "", literal: " ") } '
+        query = ' { zoomstackSites(count: 2, propertyName: "", literal: " ") } '
 
-        expected_value = {'hello': response_data["features"]}
+        expected_value = {'zoomstackSites': response_data["features"]}
         mocked_get.return_value = self.make_mocked_response(response_data)
         request = self.make_request(query)
         result = graphqlwfs(request)
@@ -65,18 +64,18 @@ class HelloTestCase(unittest.TestCase):
         self.assertEqual(result, expected_value)
 
     @patch('main.requests.get')
-    def test_counter_negative(self, mocked_get):
+    def test_zoomstackSites_counter_negative(self, mocked_get):
         response_data = 'Error: Count needs to be 0 or more'
-        query = ' { hello(count: -5, propertyName: "Type", literal: "Education") } '
+        query = ' { zoomstackSites(count: -5, propertyName: "Type", literal: "Education") } '
 
-        expected_value = {'hello': [response_data]}
+        expected_value = {'zoomstackSites': [response_data]}
         mocked_get.return_value = self.make_mocked_response(response_data)
         request = self.make_request(query)
         result = graphqlwfs(request)
 
         self.assertEqual(result, expected_value)
 
-    def test_buildWFSQuery_hello(self):
+    def test_zoomstackSites_buildWFSQuery(self):
         count = 1
         typeNames = None
         filters = {


### PR DESCRIPTION
- refactored hello to zoomstackSites query
- removed typeNames parameter since zoomstackSites was being used as the default therefore only Zoomstack_Sites typeName will be used for this query.
- refactored json(_) to json(self) to remove linting errors.